### PR TITLE
Simplify Secret Generation Commands

### DIFF
--- a/plugins/jwt-auth/README.md
+++ b/plugins/jwt-auth/README.md
@@ -54,11 +54,11 @@ The `secret` string is required when using HMAC. The secret should not be commit
 characters long. You can generate a strong secret using a tool like openssl or gpg:
 
 ```console
-openssl rand -base64 32 | cut -c1-32
+openssl rand -base64 24
 ```
 
 ```console
-gpg --gen-random 1 32 | base64 | cut -c1-32
+gpg --armor --gen-random 1 24
 ```
 
 #### keys

--- a/plugins/jwt-auth/assets/mixerapi_jwtauth.php
+++ b/plugins/jwt-auth/assets/mixerapi_jwtauth.php
@@ -13,7 +13,7 @@ return [
         /*
          * This is only required if you are using HMAC, it can be left empty otherwise. The value must be at least
          * 32 characters long, secure, and not be committed to your VCS. You can generate a secure secret using
-         * something like `openssl rand -base64 32` or `gpg --gen-random 1 32 | base64`
+         * something like `openssl rand -base64 24` or `gpg --armor --gen-random 1 24`
          */
         'secret' => null, // file_get_contents(CONFIG . 'keys' . DS . 'hmac_secret.txt'),
 


### PR DESCRIPTION
When base64 encoding, every 6 bytes of input is turned into 8 bytes of output. In our examples 24 bytes of input is turned into 32 bytes of output.

For gpg example we use `--armor` flag to base64 encode the output.
