### PR TITLE
CakePHP 5.1 deprecations

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.3']
+        php-versions: ['8.1', '8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -115,3 +115,33 @@ jobs:
           rm -rf composer.lock
           composer install
           vendor/bin/phpunit plugins/${{matrix.plugin}}
+
+  #
+  # CakePHP version compatability
+  #
+  cakephp_version_compatibility:
+    name: CakePHP ${{ matrix.version }} Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: ['~5.0', '~5.1']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          extensions: mbstring, intl
+
+      - name: PHP Version
+        run: php -v
+
+      - name: CakePHP ${{matrix.version}} Compatability
+        run: |
+          composer self-update
+          rm -rf composer.lock
+          composer require cakephp/cakephp:${{matrix.version}} --no-update
+          composer install --prefer-dist --no-progress
+          composer test

--- a/config/app.php
+++ b/config/app.php
@@ -108,7 +108,7 @@ return [
          * Duration will be set to '+2 minutes' in bootstrap.php when debug = true
          * If you set 'className' => 'Null' core cache will be disabled.
          */
-        '_cake_core_' => [
+        '_cake_translations_' => [
             'className' => FileEngine::class,
             'prefix' => 'myapp_cake_core_',
             'path' => CACHE . 'persistent' . DS,

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,5 +3,6 @@ parameters:
 	checkGenericClassInNonGenericObjectType: false
 	checkMissingIterableValueType: false
 	treatPhpDocTypesAsCertain: false
+	reportUnmatchedIgnoredErrors: false
 	excludePaths:
 		- plugins/exception-render/src/OpenApiExceptionSchema.php

--- a/plugins/hal-view/src/JsonSerializer.php
+++ b/plugins/hal-view/src/JsonSerializer.php
@@ -118,7 +118,7 @@ class JsonSerializer
     {
         try {
             if ($collection instanceof PaginatedResultSet) {
-                $entity = $collection->items()->first();
+                $entity = $collection->toArray()[0];
             } else {
                 $entity = $collection->first();
             }

--- a/plugins/hal-view/src/JsonSerializer.php
+++ b/plugins/hal-view/src/JsonSerializer.php
@@ -117,7 +117,11 @@ class JsonSerializer
     private function collection(mixed $collection): array
     {
         try {
-            $entity = $collection->first();
+            if ($collection instanceof PaginatedResultSet) {
+                $entity = $collection->items()->first();
+            } else {
+                $entity = $collection->first();
+            }
             $tableName = Inflector::tableize((new ReflectionClass($entity))->getShortName());
         } catch (ReflectionException $e) {
             $tableName = 'data';

--- a/plugins/json-ld-view/src/JsonSerializer.php
+++ b/plugins/json-ld-view/src/JsonSerializer.php
@@ -138,7 +138,12 @@ class JsonSerializer
         $return = [];
 
         try {
-            $entity = $jsonLd->first();
+            if ($jsonLd instanceof PaginatedResultSet) {
+                $entity = $jsonLd->items()->first();
+            } else {
+                $entity = $jsonLd->first();
+            }
+
             if ($entity instanceof JsonLdDataInterface) {
                 $return['@context'] = $entity->getJsonLdContext();
             }

--- a/plugins/json-ld-view/src/JsonSerializer.php
+++ b/plugins/json-ld-view/src/JsonSerializer.php
@@ -139,7 +139,7 @@ class JsonSerializer
 
         try {
             if ($jsonLd instanceof PaginatedResultSet) {
-                $entity = $jsonLd->items()->first();
+                $entity = $jsonLd->toArray()[0];
             } else {
                 $entity = $jsonLd->first();
             }


### PR DESCRIPTION
Adds
- PHP 8.1 and 8.4 to git pipeline checks
- CakePHP 5.0 and 5.1 to git pipeline checks

Resolves:

```
Deprecated: Since 5.1.0: Calling `Cake\ORM\ResultSet` methods, such as `first()`, on 
PaginatedResultSet is deprecated. You must call `items()` first (for example, `items()->first()`).
```