### PR TITLE
Fix chained exceptions serializing as empty JSON objects

### DIFF
--- a/plugins/exception-render/src/MixerApiExceptionRenderer.php
+++ b/plugins/exception-render/src/MixerApiExceptionRenderer.php
@@ -73,11 +73,22 @@ class MixerApiExceptionRenderer extends WebExceptionRenderer
         }
         $response = $response->withStatus($code);
 
-        $exceptions = [$exception];
-        $previous = $exception->getPrevious();
-        while ($previous != null) {
-            $exceptions[] = $previous;
-            $previous = $previous->getPrevious();
+        $exceptions = [];
+        $current = $exception;
+        while ($current !== null) {
+            $exceptionData = [
+                'class' => (new ReflectionClass($current))->getShortName(),
+                'message' => $current->getMessage(),
+                'code' => $current->getCode(),
+            ];
+
+            if (Configure::read('debug')) {
+                $exceptionData['file'] = $current->getFile();
+                $exceptionData['line'] = $current->getLine();
+            }
+
+            $exceptions[] = $exceptionData;
+            $current = $current->getPrevious();
         }
 
         $viewVars = [

--- a/plugins/exception-render/src/MixerApiExceptionRenderer.php
+++ b/plugins/exception-render/src/MixerApiExceptionRenderer.php
@@ -73,21 +73,11 @@ class MixerApiExceptionRenderer extends WebExceptionRenderer
         }
         $response = $response->withStatus($code);
 
+        $maxExceptions = 10;
         $exceptions = [];
         $current = $exception;
-        while ($current !== null) {
-            $exceptionData = [
-                'class' => (new ReflectionClass($current))->getShortName(),
-                'message' => $current->getMessage(),
-                'code' => $current->getCode(),
-            ];
-
-            if (Configure::read('debug')) {
-                $exceptionData['file'] = $current->getFile();
-                $exceptionData['line'] = $current->getLine();
-            }
-
-            $exceptions[] = $exceptionData;
+        while ($current !== null && count($exceptions) < $maxExceptions) {
+            $exceptions[] = new SerializableException($current);
             $current = $current->getPrevious();
         }
 

--- a/plugins/exception-render/src/MixerApiExceptionRenderer.php
+++ b/plugins/exception-render/src/MixerApiExceptionRenderer.php
@@ -74,9 +74,11 @@ class MixerApiExceptionRenderer extends WebExceptionRenderer
         $response = $response->withStatus($code);
 
         $maxExceptions = 10;
+        $depth = 0;
         $exceptions = [];
         $current = $exception;
-        while ($current !== null && count($exceptions) < $maxExceptions) {
+        while ($current !== null && $depth < $maxExceptions) {
+            $depth++;
             $exceptions[] = new SerializableException($current);
             $current = $current->getPrevious();
         }

--- a/plugins/exception-render/src/SerializableException.php
+++ b/plugins/exception-render/src/SerializableException.php
@@ -12,14 +12,20 @@ class SerializableException extends \Exception implements JsonSerializable
 {
     private Throwable $wrapped;
 
+    /**
+     * @param \Throwable $exception The exception to wrap
+     */
     public function __construct(Throwable $exception)
     {
         $this->wrapped = $exception;
-        parent::__construct($exception->getMessage(), (int) $exception->getCode());
+        parent::__construct($exception->getMessage(), (int)$exception->getCode());
         $this->file = $exception->getFile();
         $this->line = $exception->getLine();
     }
 
+    /**
+     * @return array
+     */
     public function jsonSerialize(): array
     {
         $data = [

--- a/plugins/exception-render/src/SerializableException.php
+++ b/plugins/exception-render/src/SerializableException.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace MixerApi\ExceptionRender;
+
+use Cake\Core\Configure;
+use JsonSerializable;
+use ReflectionClass;
+use Throwable;
+
+class SerializableException extends \Exception implements JsonSerializable
+{
+    private Throwable $wrapped;
+
+    public function __construct(Throwable $exception)
+    {
+        $this->wrapped = $exception;
+        parent::__construct($exception->getMessage(), (int) $exception->getCode());
+        $this->file = $exception->getFile();
+        $this->line = $exception->getLine();
+    }
+
+    public function jsonSerialize(): array
+    {
+        $data = [
+            'class' => (new ReflectionClass($this->wrapped))->getShortName(),
+            'message' => $this->getMessage(),
+            'code' => $this->getCode(),
+        ];
+
+        if (Configure::read('debug')) {
+            $data['file'] = $this->getFile();
+            $data['line'] = $this->getLine();
+        }
+
+        return $data;
+    }
+}

--- a/plugins/exception-render/tests/TestCase/MixerApiExceptionRenderTest.php
+++ b/plugins/exception-render/tests/TestCase/MixerApiExceptionRenderTest.php
@@ -2,7 +2,6 @@
 
 namespace MixerApi\ExceptionRender\Test\TestCase;
 
-use Cake\Core\Exception\CakeException;
 use Cake\Http\Exception\HttpException;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
@@ -11,6 +10,35 @@ use MixerApi\ExceptionRender\ValidationException;
 
 class MixerApiExceptionRenderTest extends TestCase
 {
+    public function test_chained_exceptions_serialize_as_structured_arrays(): void
+    {
+        $previous = new \RuntimeException('Connection refused', 111);
+        $exception = new HttpException('Service unavailable', 503, $previous);
+
+        $request = new ServerRequest();
+        $request = $request->withHeader('Accept', 'application/json');
+        $request = $request->withHeader('Content-Type', 'application/json');
+
+        $response = (new MixerApiExceptionRenderer($exception, $request))->render();
+
+        $body = json_decode((string)$response->getBody(), true);
+        $exceptions = $body['exceptions'];
+
+        $this->assertCount(2, $exceptions);
+
+        $this->assertEquals('HttpException', $exceptions[0]['class']);
+        $this->assertEquals('Service unavailable', $exceptions[0]['message']);
+        $this->assertEquals(503, $exceptions[0]['code']);
+        $this->assertArrayHasKey('file', $exceptions[0]);
+        $this->assertArrayHasKey('line', $exceptions[0]);
+
+        $this->assertEquals('RuntimeException', $exceptions[1]['class']);
+        $this->assertEquals('Connection refused', $exceptions[1]['message']);
+        $this->assertEquals(111, $exceptions[1]['code']);
+        $this->assertArrayHasKey('file', $exceptions[1]);
+        $this->assertArrayHasKey('line', $exceptions[1]);
+    }
+
     public function test_get_error(): void
     {
         $this->assertInstanceOf(

--- a/plugins/exception-render/tests/TestCase/MixerApiExceptionRenderTest.php
+++ b/plugins/exception-render/tests/TestCase/MixerApiExceptionRenderTest.php
@@ -2,6 +2,7 @@
 
 namespace MixerApi\ExceptionRender\Test\TestCase;
 
+use Cake\Event\EventManager;
 use Cake\Http\Exception\HttpException;
 use Cake\Http\ServerRequest;
 use Cake\TestSuite\TestCase;
@@ -37,6 +38,51 @@ class MixerApiExceptionRenderTest extends TestCase
         $this->assertEquals(111, $exceptions[1]['code']);
         $this->assertArrayHasKey('file', $exceptions[1]);
         $this->assertArrayHasKey('line', $exceptions[1]);
+    }
+
+    public function test_exception_chain_is_capped_at_max_depth(): void
+    {
+        $exception = new \RuntimeException('root');
+        for ($i = 0; $i < 11; $i++) {
+            $exception = new \RuntimeException("level $i", 0, $exception);
+        }
+
+        $request = new ServerRequest();
+        $request = $request->withHeader('Accept', 'application/json');
+        $request = $request->withHeader('Content-Type', 'application/json');
+
+        $response = (new MixerApiExceptionRenderer($exception, $request))->render();
+
+        $body = json_decode((string)$response->getBody(), true);
+        $this->assertCount(10, $body['exceptions']);
+    }
+
+    public function test_chained_exceptions_are_throwable_for_event_listeners(): void
+    {
+        $previous = new \RuntimeException('Connection refused', 111);
+        $exception = new HttpException('Service unavailable', 503, $previous);
+
+        $request = new ServerRequest();
+        $request = $request->withHeader('Accept', 'application/json');
+        $request = $request->withHeader('Content-Type', 'application/json');
+
+        $captured = null;
+        EventManager::instance()->on(
+            'MixerApi.ExceptionRender.beforeRender',
+            function ($event) use (&$captured) {
+                $captured = $event->getSubject()->getViewVars()['exceptions'];
+            }
+        );
+
+        (new MixerApiExceptionRenderer($exception, $request))->render();
+
+        $this->assertCount(2, $captured);
+        $this->assertInstanceOf(\Throwable::class, $captured[0]);
+        $this->assertInstanceOf(\Throwable::class, $captured[1]);
+        $this->assertEquals('Service unavailable', $captured[0]->getMessage());
+        $this->assertEquals('Connection refused', $captured[1]->getMessage());
+
+        EventManager::instance()->off('MixerApi.ExceptionRender.beforeRender');
     }
 
     public function test_get_error(): void

--- a/plugins/exception-render/tests/TestCase/SerializableExceptionTest.php
+++ b/plugins/exception-render/tests/TestCase/SerializableExceptionTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace MixerApi\ExceptionRender\Test\TestCase;
+
+use Cake\Core\Configure;
+use Cake\TestSuite\TestCase;
+use MixerApi\ExceptionRender\SerializableException;
+
+class SerializableExceptionTest extends TestCase
+{
+    public function test_is_throwable(): void
+    {
+        $wrapped = new \RuntimeException('test');
+        $exception = new SerializableException($wrapped);
+
+        $this->assertInstanceOf(\Throwable::class, $exception);
+    }
+
+    public function test_is_json_serializable(): void
+    {
+        $wrapped = new \RuntimeException('test');
+        $exception = new SerializableException($wrapped);
+
+        $this->assertInstanceOf(\JsonSerializable::class, $exception);
+    }
+
+    public function test_proxies_message_and_code(): void
+    {
+        $wrapped = new \RuntimeException('Connection refused', 111);
+        $exception = new SerializableException($wrapped);
+
+        $this->assertEquals('Connection refused', $exception->getMessage());
+        $this->assertEquals(111, $exception->getCode());
+    }
+
+    public function test_proxies_file_and_line(): void
+    {
+        $wrapped = new \RuntimeException('test');
+        $exception = new SerializableException($wrapped);
+
+        $this->assertEquals($wrapped->getFile(), $exception->getFile());
+        $this->assertEquals($wrapped->getLine(), $exception->getLine());
+    }
+
+    public function test_json_serialize_returns_structured_data(): void
+    {
+        $wrapped = new \RuntimeException('Connection refused', 111);
+        $exception = new SerializableException($wrapped);
+
+        Configure::write('debug', true);
+        $data = $exception->jsonSerialize();
+
+        $this->assertEquals('RuntimeException', $data['class']);
+        $this->assertEquals('Connection refused', $data['message']);
+        $this->assertEquals(111, $data['code']);
+        $this->assertArrayHasKey('file', $data);
+        $this->assertArrayHasKey('line', $data);
+    }
+
+    public function test_json_serialize_excludes_file_and_line_without_debug(): void
+    {
+        $wrapped = new \RuntimeException('Connection refused', 111);
+        $exception = new SerializableException($wrapped);
+
+        Configure::write('debug', false);
+        $data = $exception->jsonSerialize();
+
+        $this->assertEquals('RuntimeException', $data['class']);
+        $this->assertEquals('Connection refused', $data['message']);
+        $this->assertEquals(111, $data['code']);
+        $this->assertArrayNotHasKey('file', $data);
+        $this->assertArrayNotHasKey('line', $data);
+
+        Configure::write('debug', true);
+    }
+
+    public function test_json_encode_produces_correct_output(): void
+    {
+        $wrapped = new \RuntimeException('test', 42);
+        $exception = new SerializableException($wrapped);
+
+        Configure::write('debug', false);
+        $json = json_encode($exception);
+        $decoded = json_decode($json, true);
+
+        $this->assertEquals('RuntimeException', $decoded['class']);
+        $this->assertEquals('test', $decoded['message']);
+        $this->assertEquals(42, $decoded['code']);
+
+        Configure::write('debug', true);
+    }
+}


### PR DESCRIPTION
Closes #163

## Summary

The exception chain collector in `MixerApiExceptionRenderer` stored raw `Throwable` objects in the `exceptions` viewVar. Since PHP's `Exception` class has only protected properties and does not implement `JsonSerializable`, `json_encode` produced `{}` for each entry. This wraps each exception in a `SerializableException` that extends `Exception` and implements `JsonSerializable`, preserving the `Throwable` contract for event listeners while producing structured JSON output.

## Major Changes

- Add `SerializableException` class that extends `Exception` and implements `JsonSerializable`, wrapping each exception in the chain to produce structured JSON while remaining a `Throwable`
- Include `file` and `line` when `debug` is enabled, consistent with how the renderer already handles trace/origin data for the primary exception
- Cap exception chain traversal at 10 iterations to guard against circular chains

## Minor Changes

- Remove unused `CakeException` import from `MixerApiExceptionRenderTest`
- Use strict comparison (`!==`) in the chain-walking loop

## ~~Backwards Compatibility Notes~~ (superseded)

~~This changes the type of the `exceptions` viewVar from `Throwable[]` to `array[]` (array of associative arrays). Two considerations:~~

- ~~**JSON output**: Changes from `[{}, {}]` to `[{"class": "...", "message": "...", "code": ...}, ...]`. The previous output was a serialization bug (empty objects), so no consumer could have been meaningfully depending on it.~~
- ~~**Event listeners**: Any listener on `MixerApi.ExceptionRender.beforeRender` that accesses `$viewVars['exceptions']` and calls Throwable methods on the entries (e.g., `$e->getMessage()`) would need to update to array access (e.g., `$e['message']`). The `ErrorDecorator` itself is a passive container and is unaffected.~~
- ~~**Production mode**: `debugViewVars()` unsets the `exceptions` key entirely when `debug = false`, so production output is unchanged.~~

## Backwards Compatibility Notes (updated)

The `exceptions` viewVar entries are now `SerializableException` instances instead of raw `Throwable` objects. `SerializableException` extends `Exception` (and therefore implements `Throwable`), so:

- **Event listeners**: Any listener on `MixerApi.ExceptionRender.beforeRender` that calls `Throwable` methods (`getMessage()`, `getCode()`, `getFile()`, `getLine()`) on chain entries continues to work unchanged. These methods return the original exception's values.
- **JSON output**: Changes from `[{}, {}]` to structured objects with `class`, `message`, `code` (plus `file` and `line` in debug mode). The previous output was a serialization bug -- `json_encode` on `Throwable` produces empty objects because `Exception` properties are protected.
- **`instanceof` checks**: `$e instanceof \Throwable` and `$e instanceof \Exception` still pass. Checks for specific exception types (e.g., `$e instanceof RuntimeException`) would not match, since entries are now `SerializableException` wrappers. This is unlikely to affect real consumers.
- **Production mode**: `debugViewVars()` unsets `exceptions` entirely when `debug = false`, so production output is unchanged.

## Work Remaining

None.

## Test Plan

- [x] Run `vendor/bin/phpunit plugins/exception-render/tests/` -- all 21 tests pass
- [x] Run full suite `vendor/bin/phpunit` -- all 102 tests pass
- [x] Run `vendor/bin/phpstan analyse plugins/exception-render/src/` -- no errors